### PR TITLE
Add support for 3x3 obs types

### DIFF
--- a/neuronav/envs/README.md
+++ b/neuronav/envs/README.md
@@ -70,7 +70,9 @@ To add your own, edit [grid_env.py](./grid_env.py).
 | images | Function-Approx | `[32, 32, 3]` | `[32, 32, 3` | A 3D tensor corresponding to a unique CIFAR10 image per state. |
 | window | Function-Approx | `[64, 64, 3]` | `[64, 64, 3]` | A 3D tensor corresponding to the 5x5 local window around the agent. |
 | symbolic | Function-Approx | `[n, n, 6]` | `[n, n, 6]` | A 5D tensor corresponding to a symbolic representation of the environment state.
-| symbolic_window | Function-Approx | `[5, 5, 6]` | `[5, 5, 6]` | A 5D tensor corresponding to a symbolic representation of the environment state.
+| symbolic_window | Function-Approx | `[5, 5, 6]` | `[5, 5, 6]` | A 5D tensor corresponding to a symbolic representation of the 5x5 environment state around the agent.
+| window_tight | Function-Approx | `[64, 64, 3]` | `[64, 64, 3]` | A 3D tensor corresponding to the 3x3 local window around the agent. |
+| symbolic_window_tight | Function-Approx | `[3, 3, 6]` | `[3, 3, 6]` | A 5D tensor corresponding to a symbolic representation of the 3x3 environment state around the agent.
 
 * Where `n` is the length of the grid.
 

--- a/neuronav/envs/README.md
+++ b/neuronav/envs/README.md
@@ -8,9 +8,48 @@ These environments support the default `gym` interface which is commonly used in
 
 `GridEnv` consists of a simple 2D grid environment with various topographies and observation types.
 
+### Observation Types
+
+The `GridEnv` class also supports a variety of observation types for the agent. These vary in the amount of information provided to the agent, and in their format.
+
+Observation types can be set as an enum when initializing the environment. For example:
+
+```env = GridEnv(obs_type=GridObservation.index)```
+
+To add your own, edit [grid_env.py](./grid_env.py).
+
+| Observation | Type | Shape (Fixed Orientation) | Shape (Dynamic Orientation) | Description |
+| --- | --- | --- | --- | --- |
+| index | Tabular | `[1]` | `[1]` | An integer number representing the current state of the agent in the environment. |
+| onehot | Function-Approx | `[n * n]` | `[n * n * 4]` | A one-hot encoding of the current state of the agent in the environment. |
+| twohot | Function-Approx | `[n + n]` | `[n + n + 4]` | Two concatenated one-hot encodings of the agent's x and y coordinates in the environment. |
+| geometric | Function-Approx | `[2]` | `[3]` | Two real-valued numbers between 0 and 1 representing the x and y coordinates of the agent in the environment. |
+| boundary | Function-Approx | `[n * 4]` | `[n * 4 + 4]` | A matrix corresponding to the one-hot encodings of the distances of the agent from the nearest wall in the four cardinal directions |
+| visual | Function-Approx | `[110, 110, 3]` | `[110, 110, 3` | A 3D tensor corresponding to the RGB image of the environment. |
+| images | Function-Approx | `[32, 32, 3]` | `[32, 32, 3` | A 3D tensor corresponding to a unique CIFAR10 image per state. |
+| window | Function-Approx | `[64, 64, 3]` | `[64, 64, 3]` | A 3D tensor corresponding to the 5x5 local window around the agent. |
+| symbolic | Function-Approx | `[n, n, 6]` | `[n, n, 6]` | A 3D tensor corresponding to a symbolic representation of the environment state. |
+| symbolic_window | Function-Approx | `[5, 5, 6]` | `[5, 5, 6]` | A 3D tensor corresponding to a symbolic representation of the 5x5 environment state around the agent. |
+| window_tight | Function-Approx | `[64, 64, 3]` | `[64, 64, 3]` | A 3D tensor corresponding to the 3x3 local window around the agent. |
+| symbolic_window_tight | Function-Approx | `[3, 3, 6]` | `[3, 3, 6]` | A 3D tensor corresponding to a symbolic representation of the 3x3 environment state around the agent. |
+
+* Where `n` is the length of the grid.
+
+### Objects
+
+There are a number of possible objects which can be placed at various locations in a grid environment by utilizing an `objects` dictionary. They are as follows:
+
+| Object | Usage | Description | Color | Image |
+| --- | --- | --- | --- | --- |
+| reward | `'rewards': {(x, y): [v, o, t]}`, where `x, y` is the location of the reward, `o` is whether the reward should be visible, `v` is the value of the reward, and `t` is whether the episode should terminate when the agent reaches the reward. | A reward object. Provides the agent with the reward value if it occupies the location. | Blue (Pos) / Red (Neg) | ![reward_pos](/images/objects/reward_pos.png) ![reward_neg](/images/objects/reward_neg.png) |
+| marker | `'markers': {(x, y): (r, g, b)}`, where `x, y` is the location of the marker, and `r, g, b` are the color values for the marker. | A marker object. Used to provide contextual information to the agent. | Variable | N/A |
+| key | `'keys': [(x, y)]`, where `x, y` is the location of the key. | A consumable key object. Allows the agent to open a door. | Yellow | ![key](/images/objects/key.png) |
+| door | `'doors': {(x, y): o}`, where `x, y` is the location of the door, and `o` is the orientation of the door (either 'h' or 'v'). | A door object. Agent cannot enter a location with a door unless it posesses a key, which is consumed upon entry. | Green | ![door](/images/objects/door.png) |
+| warp | `'warps': {(x, y): (a, b)}`, where `x, y` is the location of the warp, and `a, b` is the location of the warp target. | A warp object. Transports the agent from the location of the warp to a specificed other location in the environment. | Purple | ![warp](/images/objects/warp.png) |
+
 ### Templates
 
-The `GridEnv` class can generate a variety of different maze layouts by selecting one of the predefined template layouts. Below is a list of the templates which are included. Templates can be set as an enum when initializing the environment. For example: 
+The `GridEnv` class can generate a variety of different maze layouts by selecting one of the predefined template layouts. Below is a list of the templates which are included. Templates can be set as an enum when initializing the environment. For example:
 
 ```env = GridEnv(template=GridTemplate.empty)```
 
@@ -37,52 +76,31 @@ The `GridEnv` class can generate a variety of different maze layouts by selectin
 | two_step | ![two_step](/images/grid_small/two_step.png) | ![two_step](/images/grid_large/two_step.png) | |
 | narrow | ![narrow](/images/grid_small/narrow.png) | ![narrow](/images/grid_large/narrow.png) | [Zorowitz et al., 2020](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8143038/) |
 
-### Objects
+## GraphEnv
 
-There are a number of possible objects which can be placed at various locations in a grid environment by utilizing an `objects` dictionary. They are as follows:
-
-| Object | Usage | Description | Color | Image |
-| --- | --- | --- | --- | --- |
-| reward | `'rewards': {(x, y): [v, o, t]}`, where `x, y` is the location of the reward, `o` is whether the reward should be visible, `v` is the value of the reward, and `t` is whether the episode should terminate when the agent reaches the reward. | A reward object. Provides the agent with the reward value if it occupies the location. | Blue (Pos) / Red (Neg) | ![reward_pos](/images/objects/reward_pos.png) ![reward_neg](/images/objects/reward_neg.png) |
-| marker | `'markers': {(x, y): (r, g, b)}`, where `x, y` is the location of the marker, and `r, g, b` are the color values for the marker. | A marker object. Used to provide contextual information to the agent. | Variable | N/A |
-| key | `'keys': [(x, y)]`, where `x, y` is the location of the key. | A consumable key object. Allows the agent to open a door. | Yellow | ![key](/images/objects/key.png) |
-| door | `'doors': {(x, y): o}`, where `x, y` is the location of the door, and `o` is the orientation of the door (either 'h' or 'v'). | A door object. Agent cannot enter a location with a door unless it posesses a key, which is consumed upon entry. | Green | ![door](/images/objects/door.png) |
-| warp | `'warps': {(x, y): (a, b)}`, where `x, y` is the location of the warp, and `a, b` is the location of the warp target. | A warp object. Transports the agent from the location of the warp to a specificed other location in the environment. | Purple | ![warp](/images/objects/warp.png) |
+`GraphEnv` consists of a simple graph environment with various layout structures and observation types.
 
 ### Observation Types
 
-The `GridEnv` class also supports a variety of observation types for the agent. These vary in the amount of information provided to the agent, and in their format. 
+The `GraphEnv` class also supports a variety of observation types for the agent. These vary in the amount of information provided to the agent, and in their format.
 
-Observation types can be set as an enum when initializing the environment. For example: 
+Observation types can be set as an enum when initializing the environment. For example:
 
-```env = GridEnv(obs_type=GridObservation.index)```
+```env = GraphEnv(obs_type=GraphObservation.index)```
 
-To add your own, edit [grid_env.py](./grid_env.py).
+To add your own, edit [graph_env.py](./graph_env.py).
 
-| Observation | Type | Shape (Fixed Orientation) | Shape (Dynamic Orientation) | Description |
-| --- | --- | --- | --- | --- |
-| index | Tabular | `[1]` | `[1]` | An integer number representing the current state of the agent in the environment. |
-| onehot | Function-Approx | `[n * n]` | `[n * n * 4]` | A one-hot encoding of the current state of the agent in the environment. |
-| twohot | Function-Approx | `[n + n]` | `[n + n + 4]` | Two concatenated one-hot encodings of the agent's x and y coordinates in the environment. |
-| geometric | Function-Approx | `[2]` | `[3]` | Two real-valued numbers between 0 and 1 representing the x and y coordinates of the agent in the environment. |
-| boundary | Function-Approx | `[n * 4]` | `[n * 4 + 4]` | A matrix corresponding to the one-hot encodings of the distances of the agent from the nearest wall in the four cardinal directions |
-| visual | Function-Approx | `[110, 110, 3]` | `[110, 110, 3` | A 3D tensor corresponding to the RGB image of the environment. |
+| Observation | Type | Shape | Description |
+| --- | --- | --- | --- |
+| index | Tabular | `[1]` | An integer number representing the current state of the agent in the environment. |
+| onehot | Function-Approx | `[n]` | A one-hot encoding of the current state of the agent in the environment. |
 | images | Function-Approx | `[32, 32, 3]` | `[32, 32, 3` | A 3D tensor corresponding to a unique CIFAR10 image per state. |
-| window | Function-Approx | `[64, 64, 3]` | `[64, 64, 3]` | A 3D tensor corresponding to the 5x5 local window around the agent. |
-| symbolic | Function-Approx | `[n, n, 6]` | `[n, n, 6]` | A 3D tensor corresponding to a symbolic representation of the environment state.
-| symbolic_window | Function-Approx | `[5, 5, 6]` | `[5, 5, 6]` | A 3D tensor corresponding to a symbolic representation of the 5x5 environment state around the agent.
-| window_tight | Function-Approx | `[64, 64, 3]` | `[64, 64, 3]` | A 3D tensor corresponding to the 3x3 local window around the agent. |
-| symbolic_window_tight | Function-Approx | `[3, 3, 6]` | `[3, 3, 6]` | A 3D tensor corresponding to a symbolic representation of the 3x3 environment state around the agent.
 
-* Where `n` is the length of the grid.
-
-## GraphEnv
-
-`GraphEnv` consists of a simple graph environment with various layout structures and observation types. 
+* Where `n` is the number of nodes in the graph.
 
 ### Templates
 
-Graph templates can be set as an enum when initializing the environment. For example: 
+Graph templates can be set as an enum when initializing the environment. For example:
 
 ```env = GraphEnv(template=GraphTemplate.neighborhood)```
 
@@ -100,22 +118,3 @@ The graph templates can be added to by editing [graph_templates.py](./graph_temp
 | human_b | ![human_b](/images/graph/human_b.png) | [Momennejad et al., 2017](https://www.nature.com/articles/s41562-017-0180-8) |
 | t_loop | ![t_loop](/images/graph/t_loop.png) |
 | variable_magnitude | ![variable_magnitude](/images/graph/variable_magnitude.png) | [Dabney et al., 2020](https://www.nature.com/articles/s41586-019-1924-6) |
-
-
-### Observation Types
-
-The `GraphEnv` class also supports a variety of observation types for the agent. These vary in the amount of information provided to the agent, and in their format. 
-
-Observation types can be set as an enum when initializing the environment. For example: 
-
-```env = GraphEnv(obs_type=GraphObservation.index)```
-
-To add your own, edit [graph_env.py](./graph_env.py).
-
-| Observation | Type | Shape | Description |
-| --- | --- | --- | --- |
-| index | Tabular | `[1]` | An integer number representing the current state of the agent in the environment. |
-| onehot | Function-Approx | `[n]` | A one-hot encoding of the current state of the agent in the environment. |
-| images | Function-Approx | `[32, 32, 3]` | `[32, 32, 3` | A 3D tensor corresponding to a unique CIFAR10 image per state. |
-
-* Where `n` is the number of nodes in the graph.

--- a/neuronav/envs/README.md
+++ b/neuronav/envs/README.md
@@ -69,10 +69,10 @@ To add your own, edit [grid_env.py](./grid_env.py).
 | visual | Function-Approx | `[110, 110, 3]` | `[110, 110, 3` | A 3D tensor corresponding to the RGB image of the environment. |
 | images | Function-Approx | `[32, 32, 3]` | `[32, 32, 3` | A 3D tensor corresponding to a unique CIFAR10 image per state. |
 | window | Function-Approx | `[64, 64, 3]` | `[64, 64, 3]` | A 3D tensor corresponding to the 5x5 local window around the agent. |
-| symbolic | Function-Approx | `[n, n, 6]` | `[n, n, 6]` | A 5D tensor corresponding to a symbolic representation of the environment state.
-| symbolic_window | Function-Approx | `[5, 5, 6]` | `[5, 5, 6]` | A 5D tensor corresponding to a symbolic representation of the 5x5 environment state around the agent.
+| symbolic | Function-Approx | `[n, n, 6]` | `[n, n, 6]` | A 3D tensor corresponding to a symbolic representation of the environment state.
+| symbolic_window | Function-Approx | `[5, 5, 6]` | `[5, 5, 6]` | A 3D tensor corresponding to a symbolic representation of the 5x5 environment state around the agent.
 | window_tight | Function-Approx | `[64, 64, 3]` | `[64, 64, 3]` | A 3D tensor corresponding to the 3x3 local window around the agent. |
-| symbolic_window_tight | Function-Approx | `[3, 3, 6]` | `[3, 3, 6]` | A 5D tensor corresponding to a symbolic representation of the 3x3 environment state around the agent.
+| symbolic_window_tight | Function-Approx | `[3, 3, 6]` | `[3, 3, 6]` | A 3D tensor corresponding to a symbolic representation of the 3x3 environment state around the agent.
 
 * Where `n` is the length of the grid.
 

--- a/neuronav/envs/graph_env.py
+++ b/neuronav/envs/graph_env.py
@@ -37,16 +37,12 @@ class GraphEnv(Env):
         self.obs_mode = obs_type
         self.base_objects = {"rewards": {}}
         if obs_type == GraphObservation.onehot:
-            self.observation_space = spaces.Box(
-                0, 1, shape=(self.state_size,), dtype=np.int32
-            )
+            self.obs_space = spaces.Box(0, 1, shape=(self.state_size,), dtype=np.int32)
         elif obs_type == GraphObservation.index:
-            self.observation_space = spaces.Box(
-                0, self.state_size, shape=(1,), dtype=np.int32
-            )
+            self.obs_space = spaces.Box(0, self.state_size, shape=(1,), dtype=np.int32)
         elif obs_type == GraphObservation.images:
-            self.observation_space = spaces.Box(0, 1, shape=(32, 32, 3))
-            self.images = utils.cifar10()
+            self.obs_space = spaces.Box(0, 1, shape=(32, 32, 3))
+            self.images = utils.cifar10()[0]
 
     def generate_layout(self, template: GraphTemplate):
         self.template_objects, self.edges = template_map[template]()

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extras_required = {
 
 setup(
     name="neuronav",
-    version="1.2.0",
+    version="1.3.0",
     description="Neuro-Nav",
     license="Apache License 2.0",
     author="Arthur Juliani",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ required = ["numpy", "gym", "matplotlib", "scipy", "networkx", "opencv-python"]
 
 extras_required = {
     "experiments_local": ["jupyterlab", "sklearn", "torch"],
-    "experiments_remote": ["sklearn", "torch"],
+    "experiments_remote": ["scikit-learn", "torch"],
 }
 
 setup(

--- a/tests/env_test.py
+++ b/tests/env_test.py
@@ -38,8 +38,10 @@ def test_objects_grid():
 def test_graph_obs():
     for obs_type in GraphObservation:
         env = GraphEnv(obs_type=obs_type)
-        env.reset()
+        obs = env.reset()
         env.step(env.action_space.sample())
+        if obs_type != GraphObservation.index:
+            assert obs.shape == env.obs_space.shape
 
 
 def test_graph_templates():
@@ -54,16 +56,18 @@ def test_grid_orient():
         obs = env.reset()
         env.step(env.action_space.sample())
         if obs_type != GridObservation.index:
-            assert obs.shape == env.observation_space.shape
+            assert obs.shape == env.obs_space.shape
 
 
 def test_grid_obs():
     for obs_type in GridObservation:
         env = GridEnv(obs_type=obs_type)
         obs = env.reset()
+        # check that obs is not none. Output the obs_type if it is
+        assert obs is not None, obs_type
         env.step(env.action_space.sample())
         if obs_type != GridObservation.index:
-            assert obs.shape == env.observation_space.shape
+            assert obs.shape == env.obs_space.shape
 
 
 def test_grid_templates():


### PR DESCRIPTION
* Add 3x3 observation types (`symbolic_window_tight` and `window_tight`) to `GridEnv`.
* Rename `observation_space` to more succinct `obs_space`.
* Fix a few minor bugs.